### PR TITLE
Alter function pipeTableExists and workaround bsb_tbmessage 

### DIFF
--- a/app/lang/en_US.txt
+++ b/app/lang/en_US.txt
@@ -1,4 +1,4 @@
-# --- Generated at January 2, 2021, 7:39 pm --- 
+# --- Generated at January 23, 2021, 10:33 am --- 
 Abbreviation = "Abbreviation"
 Abilities = "Abilities"
 Access = "Access"

--- a/app/lang/pt_BR.txt
+++ b/app/lang/pt_BR.txt
@@ -1,4 +1,4 @@
-# --- Generated at January 2, 2021, 7:39 pm --- 
+# --- Generated at January 23, 2021, 10:33 am --- 
 Abbreviation = "Sigla"
 Abilities = "Habilidades"
 Access = "Accessar"

--- a/app/lang/tr.txt
+++ b/app/lang/tr.txt
@@ -1,4 +1,4 @@
-# --- Generated at January 2, 2021, 7:39 pm --- 
+# --- Generated at January 23, 2021, 10:33 am --- 
 Abbreviation = "K?saltma"
 Abilities = "Yetenekleri"
 Access = "Eri?im"

--- a/installer/dumps/db-install-tables.sql
+++ b/installer/dumps/db-install-tables.sql
@@ -19,7 +19,7 @@ CREATE TABLE `bbd_tbmessage` (
   CONSTRAINT `fk_bbd_tbmessage_tbperson1` FOREIGN KEY (`idperson`) REFERENCES `tbperson` (`idperson`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1;
 
-INSERT INTO bbd_tbmessage VALUES("1","1","1","Email sending issue .","The email service (SMTP) has problems when sending emails. But receiving emails (POP / IMAP) is working normally.Our infrastructure team is working to resolve the issue as quickly as possible.","2016-02-25 19:48:56","2019-12-26 19:48:00","0000-00-00 00:00:00","N","3","0");
+INSERT INTO bbd_tbmessage VALUES("1","1","1","Email sending issue .","The email service (SMTP) has problems when sending emails. But receiving emails (POP / IMAP) is working normally.Our infrastructure team is working to resolve the issue as quickly as possible.","2016-02-25 19:48:56","2019-12-26 19:48:00","2046-10-12 01:00:00","N","3","0");
 
 
 

--- a/system/model.php
+++ b/system/model.php
@@ -129,9 +129,36 @@ class Model extends System{
         return;
     }
 
+
+    /**
+     * Return if table exists in database
+     *
+     * The pipeTableExists function was previously used, however in some versions of mysql case sensitive problems
+     * were reported in the function names. Then, we replace it with a query.
+     *
+     * @param string $tableName Table name
+     * @return bool  true|false
+     *
+     * @since 1.1.10
+     *
+     * @author Rogerio Albandes <rogerio.albandes@helpdezk.cc>
+     */
     public function tableExists($tableName)
     {
-        $rs = $this->select("SELECT pipeTableExists('".$tableName."') as exist");
+
+
+        $database = $this->getConfig('db_name');
+
+        $query = "
+                SELECT 
+                  COUNT(*) as exist
+                 FROM
+                  information_schema.tables 
+                WHERE table_schema = '$database' 
+                  AND table_name = '$tableName' ;
+                 ";
+
+        $rs = $this->select($query);
         return $rs->fields['exist'];
     }
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-helpdezk-community-1.1.9
+helpdezk-community-1.1.10


### PR DESCRIPTION
The pipeTableExists function was previously used, however in some versions of mysql case sensitive problems were reported in the function names. Then, we replace it with a query.

Version 5.7. * Of mysql sets the sql_mode parameter to STRICT_TRANS_TABLES by default. This makes it impossible to use a datetime value of '000-00-00 00:00:00'

To solve the problem, just remove the STRICT_TRANS_TABLES from the sql_mode parameter. However, some users do not have access to mysql.ini, or permission to set in real time, so we created a workaround, changing the example record in the bbd_tbmessage table.